### PR TITLE
Simple serializer/deserializer for string builder composed bonaportables

### DIFF
--- a/bonaparte-core-test/src/main/bon/csvTests.bon
+++ b/bonaparte-core-test/src/main/bon/csvTests.bon
@@ -10,5 +10,10 @@ package csvTests {
         Calendar                when;
         Long                    longNum;
     }
+
+    class Test2 extends Test1 {
+        (Test1...)              test1;
+        (Test1...) List<>       tests1;
+    }
 }
 

--- a/bonaparte-core-test/src/test/java/testcases/utils/StringSerializerTest.java
+++ b/bonaparte-core-test/src/test/java/testcases/utils/StringSerializerTest.java
@@ -1,0 +1,45 @@
+package testcases.utils;
+
+import static org.testng.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import org.joda.time.LocalDate;
+import org.testng.annotations.Test;
+
+import de.jpaw.bonaparte.core.StringBuilderComposer;
+import de.jpaw.bonaparte.pojos.csvTests.Test1;
+import de.jpaw.bonaparte.pojos.csvTests.Test2;
+import de.jpaw.util.StringSerializer;
+
+public class StringSerializerTest {
+
+    @Test
+    public void bidirectionalConversion() {
+        // Given
+        Test1 test1 = new Test1();
+        test1.setString1("One param");
+
+        Test2 test2 = new Test2();
+        test2.setDay1(new LocalDate());
+        test2.setDec1(new BigDecimal(1.2d));
+        test2.setInt1(42);
+        test2.setLongNum(4200l);
+        test2.setReally(true);
+        test2.setString1("Hello \t\\");
+        test2.setTest1(test1);
+        test2.setTests1(Arrays.asList(test1, test1));
+
+        StringBuilder builder = new StringBuilder();
+        new StringBuilderComposer(builder).writeRecord(test2);
+
+        // When
+        String converted = StringSerializer.toString(builder);
+        StringBuilder reConverted = StringSerializer.fromString(converted);
+
+        // Then
+        assertEquals(builder.toString(), reConverted.toString());
+        System.out.println("StringSerializerTest, Converted output: " + converted);
+    }
+}

--- a/bonaparte-core/src/main/java/de/jpaw/util/StringSerializer.java
+++ b/bonaparte-core/src/main/java/de/jpaw/util/StringSerializer.java
@@ -1,0 +1,75 @@
+package de.jpaw.util;
+
+import de.jpaw.bonaparte.core.StringBuilderConstants;
+
+/**
+ * Converts a Bonaportable between a StringBuilder and a readable/editable String. It can be used to serialize bonaportables in text files while each
+ * bonaportable takes a single line.
+ */
+public class StringSerializer extends StringBuilderConstants {
+
+    /**
+     * The escape char to display the bonaportable control chars
+     */
+    protected static final char ESC = '\\';
+
+    /**
+     * Converts a bonaPortable provided with a Stringbuilder to a simple string representation. All bonaportable control characters, tabs and backslashes are
+     * converted to escaped chars.
+     * 
+     * @param builder
+     *            A Stringbuilder that containes a bonaportable
+     * @return the converted bonaportable
+     */
+    public static String toString(StringBuilder builder) {
+        StringBuilder result = new StringBuilder();
+        for (char c : builder.toString().toCharArray()) {
+            if (c == '\t') {
+                // special handling for tabs that only appear in ascii/unicode fields. We want java notation
+                result.append("\\t");
+            } else if (c < 32) {
+                // all chars 0..31 are control chars, prefix with \ and shift value to letter space (+64)
+                result.append('\\').append((char) (c + 64));
+            } else if (c == '\\') {
+                // escape the escape char
+                result.append("\\\\");
+            } else {
+                // leave everything else untouched
+                result.append(c);
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Converts a bonaPortable provided with a simple String representation to Stringbuilder.
+     * 
+     * @param builder
+     *            A Stringbuilder that containes a bonaportable
+     * @return the converted bonaportable
+     */
+    public static StringBuilder fromString(String string) {
+        StringBuilder result = new StringBuilder();
+        boolean escaped = false;
+        for (char c : string.toCharArray()) {
+            if (escaped) {
+                escaped = false;
+                if (c == 't') {
+                    // insert a tab
+                    result.append('\t');
+                } else if (c == '\\') {
+                    // insert a backslash
+                    result.append(c);
+                } else {
+                    // insert a control char
+                    result.append((char) (c - 64));
+                }
+            } else if (c == '\\') {
+                escaped = true;
+            } else {
+                result.append(c);
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Hi Michael,

Der serializer kann BonaPortables aus einem StringBuilder in editierbare Strings und wieder zurück konvertieren. Das wäre erstmal ein trivialer Weg, um requests in files zu schreiben, dort eventuell zu modifizieren und dann zurückzuspielen.

Ich habe alle control chars umgewandelt (z.B. '0x02' -> "\B"), '\' in "\\" und Tabs '0x09' in "\t". Ein Test ist dabei, der zeigt, dass die Konvertierung auch für komplexere Objekte in beide Richtungen funktinoiert.

Viele Grüße,
Andreas
